### PR TITLE
GitHub Actions: Go linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+    branches : [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: action/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.8
+      - name: lint
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.37.1
+          golangci-lint run


### PR DESCRIPTION
ref #3

@mcorbin running this action on ubuntu because it's the only supported OS. I don't think it's really necessary to run it on Debian but if it is, we can run it on a docker container.